### PR TITLE
fix: improve llama-cpp-python installer for Apple Silicon

### DIFF
--- a/tipo_installer.py
+++ b/tipo_installer.py
@@ -147,12 +147,12 @@ def install_llama_cpp():
     else:
         if cuda_version == "metal":
             logger.warning(
-                "Apple Silicon with Metal backend detected. "
+                "Metal Performance Shaders detected. "
                 "Prebuilt llama-cpp-python may not be available. "
-                "You may need to install it manually, as described in the repository's readme: "
-                "https://github.com/abetlen/llama-cpp-python/"
+                "For better performance, you may need to reinstall and build it manually. "
+                "Goto: https://github.com/abetlen/llama-cpp-python/"
             )
-            return
+
         logger.warning("Official wheel not found, using legacy builds")
         install_llama_cpp_legacy(cuda_version, has_cuda)
         return

--- a/tipo_installer.py
+++ b/tipo_installer.py
@@ -129,11 +129,14 @@ def install_llama_cpp():
 
     if has_metal:
         # torch.version.cuda is None on Apple Silicon
-        cuda_version = None
+        cuda_version = ""
         arch = "metal"
-    else:
+    elif has_cuda:
         cuda_version = torch.version.cuda.replace(".", "")
-        arch = "cu" + cuda_version if has_cuda else "cpu"
+        arch = "cu" + cuda_version
+    else:
+        cuda_version = ""
+        arch = "cpu"
 
     if has_cuda and arch > "cu124":
         arch = "cu124"

--- a/tipo_installer.py
+++ b/tipo_installer.py
@@ -1,13 +1,13 @@
 ##
 ## ====================== Installer ======================
 ##
-import os
-import sys
-import logging
 import copy
-import pkg_resources
+import logging
+import os
 import subprocess
+import sys
 
+import pkg_resources
 
 KGEN_VERSION = "0.2.0"
 python = sys.executable
@@ -115,11 +115,6 @@ def install_llama_cpp():
     logger.info("Attempting to install LLaMA-CPP-Python")
     import torch
 
-    has_cuda = torch.cuda.is_available()
-    cuda_version = torch.version.cuda.replace(".", "")
-    arch = "cu" + cuda_version if has_cuda else "cpu"
-    if has_cuda and arch > "cu124":
-        arch = "cu124"
     platform = sys.platform
     py_ver = f"cp{sys.version_info.major}{sys.version_info.minor}"
     if platform == "darwin":
@@ -128,6 +123,24 @@ def install_llama_cpp():
         platform = "win_amd64"
     elif platform == "linux":
         platform = "linux_x86_64"
+
+    has_cuda = torch.cuda.is_available()
+    has_metal = torch.backends.mps.is_available() and torch.backends.mps.is_built()
+    if has_metal:
+        logger.warning(
+            "Apple Silicon with Metal backend detected. "
+            "Prebuilt llama-cpp-python may not be available. "
+            "You may need to install it manually, as described in the repository's readme: "
+            "https://github.com/abetlen/llama-cpp-python/"
+        )
+    if has_metal:
+        # torch.version.cuda is None on Apple Silicon
+        cuda_version = None
+    else:
+        cuda_version = torch.version.cuda.replace(".", "")
+    arch = "cu" + cuda_version if has_cuda else "cpu"
+    if has_cuda and arch > "cu124":
+        arch = "cu124"
 
     for version, (py_vers, archs, platforms) in version_arch.items():
         if py_ver in py_vers and arch in archs and platform in platforms:

--- a/tipo_installer.py
+++ b/tipo_installer.py
@@ -127,13 +127,13 @@ def install_llama_cpp():
     has_cuda = torch.cuda.is_available()
     has_metal = torch.backends.mps.is_available() and torch.backends.mps.is_built()
 
-    if has_metal:
+    if has_cuda:
+        cuda_version = torch.version.cuda.replace(".", "")
+        arch = "cu" + cuda_version
+    elif has_metal:
         # torch.version.cuda is None on Apple Silicon
         cuda_version = ""
         arch = "metal"
-    elif has_cuda:
-        cuda_version = torch.version.cuda.replace(".", "")
-        arch = "cu" + cuda_version
     else:
         cuda_version = ""
         arch = "cpu"

--- a/tipo_installer.py
+++ b/tipo_installer.py
@@ -126,19 +126,15 @@ def install_llama_cpp():
 
     has_cuda = torch.cuda.is_available()
     has_metal = torch.backends.mps.is_available() and torch.backends.mps.is_built()
-    if has_metal:
-        logger.warning(
-            "Apple Silicon with Metal backend detected. "
-            "Prebuilt llama-cpp-python may not be available. "
-            "You may need to install it manually, as described in the repository's readme: "
-            "https://github.com/abetlen/llama-cpp-python/"
-        )
+
     if has_metal:
         # torch.version.cuda is None on Apple Silicon
         cuda_version = None
+        arch = "metal"
     else:
         cuda_version = torch.version.cuda.replace(".", "")
-    arch = "cu" + cuda_version if has_cuda else "cpu"
+        arch = "cu" + cuda_version if has_cuda else "cpu"
+
     if has_cuda and arch > "cu124":
         arch = "cu124"
 
@@ -146,6 +142,14 @@ def install_llama_cpp():
         if py_ver in py_vers and arch in archs and platform in platforms:
             break
     else:
+        if cuda_version is None:
+            logger.warning(
+                "Apple Silicon with Metal backend detected. "
+                "Prebuilt llama-cpp-python may not be available. "
+                "You may need to install it manually, as described in the repository's readme: "
+                "https://github.com/abetlen/llama-cpp-python/"
+            )
+            return
         logger.warning("Official wheel not found, using legacy builds")
         install_llama_cpp_legacy(cuda_version, has_cuda)
         return

--- a/tipo_installer.py
+++ b/tipo_installer.py
@@ -132,7 +132,7 @@ def install_llama_cpp():
         arch = "cu" + cuda_version
     elif has_metal:
         # torch.version.cuda is None on Apple Silicon
-        cuda_version = ""
+        cuda_version = "metal"
         arch = "metal"
     else:
         cuda_version = ""
@@ -145,7 +145,7 @@ def install_llama_cpp():
         if py_ver in py_vers and arch in archs and platform in platforms:
             break
     else:
-        if cuda_version is None:
+        if cuda_version == "metal":
             logger.warning(
                 "Apple Silicon with Metal backend detected. "
                 "Prebuilt llama-cpp-python may not be available. "


### PR DESCRIPTION
Running this script on macOS returned an exception `AttributeError: 'NoneType' object has no attribute 'replace'`

Because `torch.version.cuda` is None when using the mps backend.

This PR for better exception handling on Apple silicon.

I modified it in a way that did not change the code flow as much as possible.