### PR TITLE
Move Tag Prompt and Natural Language Prompt inputs below existing prompt area

### DIFF
--- a/scripts/tipo.py
+++ b/scripts/tipo.py
@@ -138,7 +138,6 @@ class TIPOScript(scripts.Script):
         self.prompt_area = [None, None, None, None]
         self.tag_prompt_area = [None, None]
         self.prompt_area_row = [None, None]
-        self.prompt_gen_button = [None, None]
         self.tipo_accordion_row = [None, None]
         self.current_model = None
         self.on_after_component_elem_id = [
@@ -182,51 +181,51 @@ class TIPOScript(scripts.Script):
         return scripts.AlwaysVisible
 
     def ui(self, is_img2img):
-        # Create Generate Prompt button in its own row
         with self.prompt_area_row[is_img2img]:
-            prompt_gen = gr.Button(value="Generate Prompt", visible=not opts.tipo_no_extra_input)
-
-        # Create TIPO accordion in a separate row
-        with self.tipo_accordion_row[is_img2img]:
-            with (
-                InputAccordion(False, open=False, label=self.title())
-                if InputAccordion
-                else gr.Accordion(open=False, label=self.title())
-            ) as tipo_acc:
-                with gr.Row():
-                    with gr.Column():
-                        with gr.Row():
-                            with gr.Column(scale=1):
-                                if InputAccordion is None:
-                                    enabled_check = gr.Checkbox(
-                                        label="Enabled", value=False, min_width=20
+            with gr.Column(
+                scale=1, min_width=180, visible=not opts.tipo_no_extra_input
+            ):
+                prompt_gen = gr.Button(value="Generate Prompt")
+            with gr.Column(scale=6):
+                with (
+                    InputAccordion(False, open=False, label=self.title())
+                    if InputAccordion
+                    else gr.Accordion(open=False, label=self.title())
+                ) as tipo_acc:
+                    with gr.Row():
+                        with gr.Column():
+                            with gr.Row():
+                                with gr.Column(scale=1):
+                                    if InputAccordion is None:
+                                        enabled_check = gr.Checkbox(
+                                            label="Enabled", value=False, min_width=20
+                                        )
+                                    else:
+                                        enabled_check = tipo_acc
+                                    read_orig_prompt_btn = gr.Button(
+                                        size="sm",
+                                        value="Apply original prompt",
+                                        visible=False,
+                                        min_width=20,
                                     )
-                                else:
-                                    enabled_check = tipo_acc
-                                read_orig_prompt_btn = gr.Button(
-                                    size="sm",
-                                    value="Apply original prompt",
-                                    visible=False,
-                                    min_width=20,
+                                with gr.Column(scale=3):
+                                    orig_prompt_area = gr.TextArea(visible=False)
+                                    orig_prompt_light = gr.HTML("")
+                                orig_prompt_area.change(
+                                    lambda x: PROMPT_INDICATE_HTML * bool(x),
+                                    inputs=orig_prompt_area,
+                                    outputs=orig_prompt_light,
                                 )
-                            with gr.Column(scale=3):
-                                orig_prompt_area = gr.TextArea(visible=False)
-                                orig_prompt_light = gr.HTML("")
-                            orig_prompt_area.change(
-                                lambda x: PROMPT_INDICATE_HTML * bool(x),
-                                inputs=orig_prompt_area,
-                                outputs=orig_prompt_light,
-                            )
-                            orig_prompt_area.change(
-                                lambda x: gr.update(visible=bool(x)),
-                                inputs=orig_prompt_area,
-                                outputs=read_orig_prompt_btn,
-                            )
-                            read_orig_prompt_btn.click(
-                                fn=lambda x: x,
-                                inputs=[orig_prompt_area],
-                                outputs=self.prompt_area[is_img2img],
-                            )
+                                orig_prompt_area.change(
+                                    lambda x: gr.update(visible=bool(x)),
+                                    inputs=orig_prompt_area,
+                                    outputs=read_orig_prompt_btn,
+                                )
+                                read_orig_prompt_btn.click(
+                                    fn=lambda x: x,
+                                    inputs=[orig_prompt_area],
+                                    outputs=self.prompt_area[is_img2img],
+                                )
 
                             tag_length_radio = gr.Radio(
                                 label="Tags Length target",


### PR DESCRIPTION
Relocates the Tag Prompt and Natural Language Prompt input fields to appear below the existing prompt section for improved layout.
When these fields are hidden via ui-config.json, no extra whitespace is left behind.

Related to [#47](https://github.com/KohakuBlueleaf/z-tipo-extension/issues/47)

<img width="776" height="397" alt="image" src="https://github.com/user-attachments/assets/c8d1b651-5ba5-46c3-8743-c211e1e7f924" />
