### PR TITLE
[SD-WebUI/Forge] SEED LOGIC CHANGE: Execute `fix_seed` before calculating TIPO seed

### DIFF
--- a/scripts/dtg.py
+++ b/scripts/dtg.py
@@ -14,6 +14,7 @@ from modules.scripts import basedir, OnComponent
 from modules.processing import (
     StableDiffusionProcessingTxt2Img,
     StableDiffusionProcessingImg2Img,
+    fix_seed,
 )
 from modules.prompt_parser import parse_prompt_attention
 from modules.extra_networks import parse_prompt
@@ -376,6 +377,7 @@ class DTGScript(scripts.Script):
         if seed == -1:
             seed = random.randrange(4294967294)
         self.write_infotext(p, p.prompt, "BEFORE", seed, *args)
+        fix_seed(p)
         seed = int(seed + p.seed)
 
         p.prompt = self._process(p.prompt, aspect_ratio, seed, *args)

--- a/scripts/tipo.py
+++ b/scripts/tipo.py
@@ -19,6 +19,7 @@ from modules.scripts import basedir, OnComponent
 from modules.processing import (
     StableDiffusionProcessingTxt2Img,
     StableDiffusionProcessingImg2Img,
+    fix_seed,
 )
 from modules.prompt_parser import parse_prompt_attention
 from modules.extra_networks import parse_prompt
@@ -649,6 +650,7 @@ class TIPOScript(scripts.Script):
         if seed == -1:
             seed = random.randrange(4294967294)
         self.write_infotext(p, p.prompt, "BEFORE", seed, *args)
+        fix_seed(p)
         seed = int(seed + p.seed)
 
         args = list(args)


### PR DESCRIPTION
Fixes 2nd problem in #103

Reason: This will fix image re-creation in SD-WebUI/Forge when restoring prompts. Images generated prior to this change cannot be reproduced when TIPO was used with the `Upsampling timing` = `BEFORE` **and** `txt2img seed` = `-1` settings.

Prior to this change it was possible to reproduce an image by resetting the txt2img seed back to -1 after prompt restoration (if it was -1 during the initial generation).

With this change resetting to -1 is not needed anymore. The TIPO seed logic has been fixed to use the correct txt2img seed, but this will make images generated prior to this change not reproducible under a specific circumstance (`Upsampling timing` = `BEFORE` **and** `txt2img seed` = `-1`) due to logic changes.