### PR TITLE
Update version retrieval method in tipo_installer.py

### DIFF
--- a/tipo_installer.py
+++ b/tipo_installer.py
@@ -7,8 +7,13 @@ import os
 import subprocess
 import sys
 
-import pkg_resources
-
+# Replacement for deprecated pkg_resources
+try:
+    from importlib.metadata import version as get_version, PackageNotFoundError
+except ImportError:
+    # Fallback for Python < 3.8
+    import pkg_resources
+    
 KGEN_VERSION = "0.2.0"
 python = sys.executable
 
@@ -72,7 +77,12 @@ logger.debug("Logger initialized.")
 
 def get_installed_version(package: str):
     try:
-        return pkg_resources.get_distribution(package).version
+        if 'get_version' in globals():
+            # importlib.metadata check
+            return get_version(package)
+        else:
+            # Legacy pkg_resources check
+            return pkg_resources.get_distribution(package).version
     except Exception:
         return None
 


### PR DESCRIPTION
Replace deprecated pkg_resources with importlib.metadata for version retrieval.